### PR TITLE
Docker build fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-# RUN cp /bin/bash /bin/sh
+WORKDIR /AQuery2
 
 RUN apt update && apt install -y wget
 
@@ -10,17 +10,18 @@ RUN export OS_VER=`cat /etc/os-release | grep VERSION_CODENAME` &&\
 
 RUN wget --output-document=/etc/apt/trusted.gpg.d/monetdb.gpg https://dev.monetdb.org/downloads/MonetDB-GPG-KEY.gpg
 
-RUN apt update && apt install -y python3 python3-pip clang-14 libmonetdbe-dev libmonetdb-client-dev monetdb5-sql-dev git 
+RUN apt update && apt install -y python3 python3-pip clang-18 libmonetdbe-dev libmonetdb-client-dev monetdb5-sql-dev git monetdb5-sql monetdb-client libssl-dev libomp-dev
 
-RUN git clone https://github.com/sunyinqi0508/AQuery2 
+COPY . . 
 
-RUN python3 -m pip install -r AQuery2/requirements.txt --break-system-packages
+RUN python3 -m pip install -r requirements.txt --break-system-packages
+RUN python3 duckdb_install.py
 
-ENV IS_DOCKER_IMAGE=1 CXX=clang++-14
+ENV IS_DOCKER_IMAGE=1 CXX=clang++-18
 
 # First run will build cache into image
-RUN cd AQuery2 && python3 prompt.py
+RUN python3 prompt.py 
 
 # CMD cd AQuery2 && python3 prompt.py
-CMD echo "Welcome. Type python3 prompt.py to start AQuery." && cd AQuery2 && bash
+CMD echo "Welcome. Type python3 prompt.py to start AQuery." && bash
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MonetDB_LIB =
 MonetDB_INC = 
 Defines = 
 CC = $(CXX) -xc 
-CXXFLAGS = --std=c++2a
+CXXFLAGS = --std=c++20 --stdlib=libstdc++
 
 ifdef AQ_LINKER
 	CXX += -fuse-ld=$(AQ_LINKER)
@@ -85,7 +85,7 @@ else
 		MonetDB_INC += $(AQ_MONETDB_INC)
 		MonetDB_INC += -I/usr/local/include/monetdb -I/usr/include/monetdb 
 	endif
-	MonetDB_LIB += -lmonetdbe -lmonetdbsql -lbat
+	MonetDB_LIB += -lmonetdbe
 endif
 
 


### PR DESCRIPTION
Hi, I was trying to get this repository working for the NYU Advanced Database Systems class, and was running into a number of issues getting the Docker build to work.

Here is a summary of the changes I made:

- Changed the Dockerfile to use `WORKDIR` and `COPY` instead of cloning from Github (so local changes are reflected in the image)
- Clang 14 => Clang 18 (fixed some compiler bugs)
- Run `duckdb_install.py` as part of docker build (fixes issue with duckdb headers not being found)
- Remove some included libraries that couldn't be found by the linker, but don't seem to be needed
  - Note, the libraries (libbat and libmonetdbsql) are in `/usr/lib/x86_64-linux-gnu/`, but are there are `libbat-11.51.3.so` and `libmonetdbsql-11.51.3.so `. I also manually symlinked these to `libbat.so` and `libmonetdbsql.so` and that also works, but removing them was simpler.

With these changes, `prompt.py` seems to work; I get a prompt and am able to run some instructions. However, when it comes to the actual AQuery and SQL statements, there seem to issues, which I will post in a separate issue.